### PR TITLE
Fix: broken links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ this project.
 
 ## Contribution Guidelines
 
-- All contributors are expected to follow the project's [code of conduct](CODE_OF_CONDUCT.md). Please be respectful and
+- All contributors are expected to follow the project's [code of conduct](CODE_of_CONDUCT.md). Please be respectful and
 considerate towards other contributors.
 - Before starting work on a new feature or fix, check existing [issues](../../issues) and [pull requests](../../pulls)
 to avoid duplications and unnecessary discussions.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Inditex Tech FOSS repository
 
-Welcome to the official repository of the Inditex Tech's [FOSS (Free and Open Source Software) Manifesto](./ITX_FOSS_Manifesto.md), along with the basic documents and templates designed to guide and standardize the open source projects under our corporate umbrella. This initiative is part of our commitment to embracing and contributing to the open source community, ensuring our projects are accessible, contributable, and maintainable by anyone interested in pushing the boundaries of fashion retail technology.
+Welcome to the official repository of the Inditex Tech's [FOSS (Free and Open Source Software) Manifesto](./INDITEX_FOSS_Manifesto.md), along with the basic documents and templates designed to guide and standardize the open source projects under our corporate umbrella. This initiative is part of our commitment to embracing and contributing to the open source community, ensuring our projects are accessible, contributable, and maintainable by anyone interested in pushing the boundaries of fashion retail technology.
 
 ## About This Repository
 
-This repository serves as the starting point for all our open source projects. It contains [the FOSS Manifesto](./ITX_FOSS_Manifesto.md), which outlines our philosophy, commitments, and expectations regarding open source contributions and usage within our corporation. Additionally, you will find essential documents and templates necessary for initiating, maintaining, and contributing to our open source projects.
+This repository serves as the starting point for all our open source projects. It contains [the FOSS Manifesto](./INDITEX_FOSS_Manifesto.md), which outlines our philosophy, commitments, and expectations regarding open source contributions and usage within our corporation. Additionally, you will find essential documents and templates necessary for initiating, maintaining, and contributing to our open source projects.
 
 ### Contents
 
-- **[FOSS Manifesto](./ITX_FOSS_Manifesto.md)**: Our pledge and approach towards open source contributions, detailing our values, goals, and the principles guiding our open source initiatives.
+- **[FOSS Manifesto](./INDITEX_FOSS_Manifesto.md)**: Our pledge and approach towards open source contributions, detailing our values, goals, and the principles guiding our open source initiatives.
 - **[Contribution Guidelines](./CONTRIBUTING.md)**: Instructions and standards for contributing to our open source projects, ensuring a welcoming and productive environment for all participants.
 - **[Code of Conduct](./CODE_of_CONDUCT.md)**: Our commitment to providing a harassment-free experience for everyone, detailing expected behaviors and the consequences for unacceptable behavior.
 - **[Issue and Pull Request Templates](./.github/ISSUE_TEMPLATE/)**: Templates for submitting issues and pull requests, designed to streamline the contribution process and facilitate effective communication.
@@ -24,7 +24,7 @@ This repository serves as the starting point for all our open source projects. I
 
 To get involved with our open source projects or to use them as a foundation for your own, please follow these steps:
 
-1. **Read the [FOSS Manifesto](./ITX_FOSS_Manifesto.md)**: Familiarize yourself with our philosophy and commitments regarding open source software.
+1. **Read the [FOSS Manifesto](./INDITEX_FOSS_Manifesto.md)**: Familiarize yourself with our philosophy and commitments regarding open source software.
 2. **Review the [Contribution Guidelines](./CONTRIBUTING.md) and [Code of Conduct](./CODE_of_CONDUCT.md)**: Understand the standards and expectations for participating in our projects.
 3. **Utilize the [Issue and Pull Request Templates](./.github/ISSUE_TEMPLATE/)**: Facilitate communication and collaboration by using our standardized templates for contributions.
 


### PR DESCRIPTION
Fix #9 

This PR changes links pointing wrongly to the Manifesto name and CODE_of_CONDUCT name